### PR TITLE
Feature/init

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -63,4 +63,4 @@ jobs:
         ssh -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
             -o StrictHostKeyChecking=no \
             -i pado_dev_key root@localhost \
-            'nohup java -jar /opt/pado/api-server.jar > /opt/pado/api-server.log 2>&1 &'
+            'nohup java -jar /opt/pado/api-server.jar --spring.profiles.active=dev > /opt/pado/api-server.log 2>&1 &'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -51,6 +51,19 @@ jobs:
         api-server/build/libs/pado-server-0.0.1-SNAPSHOT.jar \
         root@localhost:/opt/pado/api-server.jar
 
+    - name: Upload .env file to server
+      run: |
+        echo "PADO_ID=${{ secrets.PADO_ID }}" > .env
+        echo "PADO_PW=${{ secrets.PADO_PW }}" >> .env
+        echo "PADO_MYSQL_DEV_URL=${{ secrets.PADO_MYSQL_DEV_URL }}" >> .env
+        echo "PADO_VAULT_DEV_URL=${{ secrets.PADO_VAULT_DEV_URL }}" >> .env
+        echo "PADO_MONGO_DEV_URL=${{ secrets.PADO_MONGO_DEV_URL }}" >> .env
+
+        scp -i pado_dev_key \
+          -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
+          -o StrictHostKeyChecking=no \
+          .env root@localhost:/opt/pado/.env
+
     - name: Kill running process (if any)
       run: |
         ssh -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
@@ -63,4 +76,4 @@ jobs:
         ssh -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
             -o StrictHostKeyChecking=no \
             -i pado_dev_key root@localhost \
-            'nohup java -jar /opt/pado/api-server.jar --spring.profiles.active=dev > /opt/pado/api-server.log 2>&1 &'
+            'cd /opt/pado && source .env && nohup java -jar api-server.jar --spring.profiles.active=dev > api-server.log 2>&1 &'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -76,4 +76,4 @@ jobs:
         ssh -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
             -o StrictHostKeyChecking=no \
             -i pado_dev_key root@localhost \
-            'cd /opt/pado && source .env && nohup java -jar api-server.jar --spring.profiles.active=dev > api-server.log 2>&1 &'
+            'cd /opt/pado && export `cat .env | xargs` && nohup java -jar api-server.jar --spring.profiles.active=dev > api-server.log 2>&1 &'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Run Tests and Build (in api-server)
       working-directory: api-server
-      run: ./gradlew test build
+      run: ./gradlew test build -Dspring.profiles.active=ci
 
     - name: Install cloudflared
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.vscode

--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -25,8 +25,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'com.h2database:h2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    runtimeOnly "com.mysql:mysql-connector-j"
+    implementation "org.springframework.cloud:spring-cloud-starter-vault-config:3.1.3"
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -25,11 +25,12 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.h2database:h2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 	implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     runtimeOnly "com.mysql:mysql-connector-j"
-    implementation "org.springframework.cloud:spring-cloud-starter-vault-config:3.1.3"
+    implementation "org.springframework.cloud:spring-cloud-starter-vault-config:3.1.2"
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/api-server/src/main/java/org/pado/api/PadoServerApplication.java
+++ b/api-server/src/main/java/org/pado/api/PadoServerApplication.java
@@ -2,8 +2,10 @@ package org.pado.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PadoServerApplication {
 
 	public static void main(String[] args) {

--- a/api-server/src/main/java/org/pado/api/domain/common/BaseTimeEntity.java
+++ b/api-server/src/main/java/org/pado/api/domain/common/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package org.pado.api.domain.common;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/api-server/src/main/java/org/pado/api/domain/component/Component.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/Component.java
@@ -1,0 +1,57 @@
+package org.pado.api.domain.component;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pado.api.domain.common.BaseTimeEntity;
+import org.pado.api.domain.connection.Connection;
+import org.pado.api.domain.project.Project;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "components")
+@lombok.Getter
+@lombok.Setter
+@lombok.NoArgsConstructor
+public class Component extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pid")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Component> children = new ArrayList<>();
+
+    @OneToMany(mappedBy = "from_component", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Connection> from_connections = new ArrayList<>();
+
+    @OneToMany(mappedBy = "to_component", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Connection> to_connections = new ArrayList<>();
+
+    private Component parent;
+    private Long version;
+    private String name;
+    private ComponentType type;
+    private ComponentSubType subtype;
+    private String thumnail;
+    private LocalDateTime deploy_start_time;
+    private LocalDateTime deploy_end_time;
+}

--- a/api-server/src/main/java/org/pado/api/domain/component/Component.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/Component.java
@@ -36,17 +36,17 @@ public class Component extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
+    private Component parent;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Component> children = new ArrayList<>();
 
-    @OneToMany(mappedBy = "from_component", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Connection> from_connections = new ArrayList<>();
+    @OneToMany(mappedBy = "fromComponent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Connection> fromConnections = new ArrayList<>();
 
-    @OneToMany(mappedBy = "to_component", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Connection> to_connections = new ArrayList<>();
+    @OneToMany(mappedBy = "toComponent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Connection> toConnections = new ArrayList<>();
 
-    private Component parent;
     private Long version;
     private String name;
     private ComponentType type;

--- a/api-server/src/main/java/org/pado/api/domain/component/ComponentRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/ComponentRepository.java
@@ -1,0 +1,13 @@
+package org.pado.api.domain.component;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ComponentRepository extends JpaRepository<Component, Long> {
+    List<Component> findByProjectId(Long projectId);
+    List<Component> findByParentId(Long parentId);
+    List<Component> findByNameContaining(String keyword);
+    List<Component> findByType(ComponentType type);
+    List<Component> findBySubtype(ComponentSubType subtype);
+}

--- a/api-server/src/main/java/org/pado/api/domain/component/ComponentSubType.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/ComponentSubType.java
@@ -1,0 +1,10 @@
+package org.pado.api.domain.component;
+
+public enum ComponentSubType {
+    REACT,
+    MYSQL,
+    SPRING,
+    S3,
+    EC2,
+    DOCKER,
+}

--- a/api-server/src/main/java/org/pado/api/domain/component/ComponentType.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/ComponentType.java
@@ -1,0 +1,6 @@
+package org.pado.api.domain.component;
+
+public enum ComponentType {
+    RESOURCE,
+    SERVICE
+}

--- a/api-server/src/main/java/org/pado/api/domain/connection/Connection.java
+++ b/api-server/src/main/java/org/pado/api/domain/connection/Connection.java
@@ -17,7 +17,7 @@ import jakarta.persistence.ManyToOne;
 public class Connection extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private String id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Component from_component;

--- a/api-server/src/main/java/org/pado/api/domain/connection/Connection.java
+++ b/api-server/src/main/java/org/pado/api/domain/connection/Connection.java
@@ -1,0 +1,30 @@
+package org.pado.api.domain.connection;
+
+import org.pado.api.domain.common.BaseTimeEntity;
+import org.pado.api.domain.component.Component;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+@lombok.Getter
+@lombok.Setter
+@lombok.NoArgsConstructor
+public class Connection extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Component from_component;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Component to_component;
+
+    private Long from_port;
+    private Long to_port;
+}

--- a/api-server/src/main/java/org/pado/api/domain/connection/Connection.java
+++ b/api-server/src/main/java/org/pado/api/domain/connection/Connection.java
@@ -20,11 +20,11 @@ public class Connection extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Component from_component;
+    private Component fromComponent;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Component to_component;
+    private Component toComponent;
 
-    private Long from_port;
-    private Long to_port;
+    private Long fromPort;
+    private Long toPort;
 }

--- a/api-server/src/main/java/org/pado/api/domain/connection/ConnectionRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/connection/ConnectionRepository.java
@@ -1,0 +1,14 @@
+package org.pado.api.domain.connection;
+
+import org.pado.api.domain.component.Component;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConnectionRepository extends JpaRepository<Connection, Long> {
+
+    List<Connection> findByFrom_component(Component fromComponent);
+    List<Connection> findByTo_component(Component toComponent);
+    List<Connection> findByFrom_port(Long fromPort);
+    List<Connection> findByTo_port(Long toPort);
+}

--- a/api-server/src/main/java/org/pado/api/domain/connection/ConnectionRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/connection/ConnectionRepository.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public interface ConnectionRepository extends JpaRepository<Connection, Long> {
 
-    List<Connection> findByFrom_component(Component fromComponent);
-    List<Connection> findByTo_component(Component toComponent);
-    List<Connection> findByFrom_port(Long fromPort);
-    List<Connection> findByTo_port(Long toPort);
+    List<Connection> findByFromComponent(Component fromComponent);
+    List<Connection> findByToComponent(Component toComponent);
+    List<Connection> findByFromPort(Long fromPort);
+    List<Connection> findByToPort(Long toPort);
 }

--- a/api-server/src/main/java/org/pado/api/domain/credential/Credential.java
+++ b/api-server/src/main/java/org/pado/api/domain/credential/Credential.java
@@ -1,0 +1,32 @@
+package org.pado.api.domain.credential;
+
+import org.pado.api.domain.common.BaseTimeEntity;
+import org.pado.api.domain.user.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+
+@Entity
+@Table(name = "credentials")
+@lombok.Getter
+@lombok.Setter
+@lombok.NoArgsConstructor
+public class Credential extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uid")
+    private User user;
+    private String name;
+    private String type;
+    private String description;
+}

--- a/api-server/src/main/java/org/pado/api/domain/credential/CredentialRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/credential/CredentialRepository.java
@@ -1,0 +1,9 @@
+package org.pado.api.domain.credential;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CredentialRepository extends JpaRepository<Credential, Long> {
+    Credential findByUserId(Long userId);
+    Credential findByName(String name);    
+    Credential findByType(String type);
+}

--- a/api-server/src/main/java/org/pado/api/domain/project/Project.java
+++ b/api-server/src/main/java/org/pado/api/domain/project/Project.java
@@ -1,0 +1,31 @@
+package org.pado.api.domain.project;
+
+import org.pado.api.domain.common.BaseTimeEntity;
+import org.pado.api.domain.user.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.FetchType;
+
+@Entity
+@Table(name = "projects")
+@lombok.Setter
+@lombok.Getter
+@lombok.NoArgsConstructor
+public class Project extends BaseTimeEntity{
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uid")
+    private User user;
+    private String name;
+    private String description;
+}

--- a/api-server/src/main/java/org/pado/api/domain/project/ProjectRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/project/ProjectRepository.java
@@ -1,0 +1,6 @@
+package org.pado.api.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/api-server/src/main/java/org/pado/api/domain/user/User.java
+++ b/api-server/src/main/java/org/pado/api/domain/user/User.java
@@ -1,0 +1,43 @@
+package org.pado.api.domain.user;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pado.api.domain.common.BaseTimeEntity;
+import org.pado.api.domain.credential.Credential;
+import org.pado.api.domain.project.Project;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.CascadeType;
+
+@Entity
+@Table(name = "users")
+@lombok.Getter
+@lombok.Setter
+@lombok.NoArgsConstructor
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String email;
+
+    @JsonIgnore
+    private String password;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Project> projects = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Credential> credentials = new ArrayList<>();
+}

--- a/api-server/src/main/java/org/pado/api/domain/user/UserRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/user/UserRepository.java
@@ -1,0 +1,8 @@
+package org.pado.api.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUsername(String username);
+    User findByEmail(String email);
+}

--- a/api-server/src/main/java/org/pado/api/domain/user/UserRepository.java
+++ b/api-server/src/main/java/org/pado/api/domain/user/UserRepository.java
@@ -3,6 +3,6 @@ package org.pado.api.domain.user;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByUsername(String username);
+    User findByName(String name);
     User findByEmail(String email);
 }

--- a/api-server/src/main/resources/application.yaml
+++ b/api-server/src/main/resources/application.yaml
@@ -1,16 +1,73 @@
 spring:
   application:
     name: pado-server
+  profiles:
+    active: local
+    
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
-    database-platform: org.hibernate.dialect.H2Dialect
+    url: jdbc:mysql://${PADO_MYSQL_DEV_URL}:3306/pado
+    username: ${PADO_ID}
+    password: ${PADO_PW}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  data:
+    mongodb:
+      uri: mongodb://${PADO_ID}:${PADO_PW}@${PADO_MONGO_DEV_URL}:27017/pado
+
+  cloud:
+    vault:
+      uri: http://${PADO_VAULT_DEV_URL}:8200
+      token: ${VAULT_DEV_TOKEN}
+      scheme: http
+      authentication: TOKEN
+      connection-timeout: 5000
+      read-timeout: 15000
+      config:
+        lifecycle:
+          enabled: false
+
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+        profile-separator: '-'
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/pado
+    username: ${PADO_ID}
+    password: ${PADO_PW}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  data:
+    mongodb:
+      uri: mongodb://${PADO_ID}:${PADO_PW}@localhost:27017/pado
+
+  cloud:
+    vault:
+      uri: http://localhost:8200
+      token: ${VAULT_DEV_TOKEN}
+      scheme: http
+      authentication: TOKEN
+      connection-timeout: 5000
+      read-timeout: 15000
+      config:
+        lifecycle:
+          enabled: false
+
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+        profile-separator: '-'

--- a/api-server/src/main/resources/application.yaml
+++ b/api-server/src/main/resources/application.yaml
@@ -9,6 +9,10 @@ spring:
   config:
     activate:
       on-profile: dev
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
 
   datasource:
     url: jdbc:mysql://${PADO_MYSQL_DEV_URL}:3306/pado
@@ -51,6 +55,11 @@ spring:
   config:
     activate:
       on-profile: local
+      
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
 
   datasource:
     url: jdbc:mysql://localhost:3306/pado

--- a/api-server/src/main/resources/application.yaml
+++ b/api-server/src/main/resources/application.yaml
@@ -16,6 +16,14 @@ spring:
     password: ${PADO_PW}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
   data:
     mongodb:
       uri: mongodb://${PADO_ID}:${PADO_PW}@${PADO_MONGO_DEV_URL}:27017/pado
@@ -50,6 +58,14 @@ spring:
     password: ${PADO_PW}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  
   data:
     mongodb:
       uri: mongodb://${PADO_ID}:${PADO_PW}@localhost:27017/pado

--- a/api-server/src/main/resources/application.yaml
+++ b/api-server/src/main/resources/application.yaml
@@ -8,6 +8,27 @@ spring:
 spring:
   config:
     activate:
+      on-profile: ci
+
+  datasource:
+    url: jdbc:h2:mem:ci_testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+
+  cloud:
+    vault:
+      enabled: false
+
+---
+spring:
+  config:
+    activate:
       on-profile: dev
   h2:
     console:
@@ -55,7 +76,7 @@ spring:
   config:
     activate:
       on-profile: local
-      
+
   h2:
     console:
       enabled: true

--- a/api-server/src/test/java/org/pado/api/PadoServerApplicationTests.java
+++ b/api-server/src/test/java/org/pado/api/PadoServerApplicationTests.java
@@ -2,8 +2,10 @@ package org.pado.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("ci")
 class PadoServerApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 🔗 연관된 이슈
Closes #3 프로젝트 초기화


## 📋 작업 내용
Pado API 서버의 핵심 도메인 모델과 레포지토리 구성,  
JPA 감사 기능 활성화,  
MySQL, MongoDB, Vault 연동 설정,  
그리고 배포 워크플로우 개선을 통해  
**비즈니스 로직 개발과 영속성 기반을 마련합니다.**

---

### 🧩 도메인 모델 및 영속 계층 설정

- `User`, `Project`, `Credential`, `Component`, `Connection` 엔티티 클래스를 새로 추가하고,  
  JPA 애너테이션과 관계 설정을 통해 애플리케이션의 핵심 데이터 구조를 구성했습니다.

- 이들 엔티티에 대한 CRUD 및 커스텀 쿼리를 지원하는 Spring Data JPA 기반의 Repository 인터페이스를 추가했습니다.  

- 전체 엔티티에서 생성/수정 시간을 자동 기록할 수 있도록 `BaseTimeEntity` 공통 엔티티를 도입했습니다.

- `@EnableJpaAuditing` 애너테이션을 통해 JPA 감사 기능을 메인 클래스에서 활성화했습니다.

---

### ⚙️ 인프라 및 설정 구성

- `build.gradle`에 MySQL, MongoDB, JPA, Vault 관련 의존성을 추가하여 데이터베이스 및 시크릿 관리 기능을 통합했습니다.

- `application.yaml`을 `local`, `dev` 프로파일로 구분하고,  
  MySQL, MongoDB, Vault 접속 정보 및 자격증명을 환경변수를 통해 주입받을 수 있도록 리팩토링했습니다.

---

### 🚀 배포 워크플로우 개선

- GitHub Actions 배포 파이프라인을 개선하여,  
  GitHub Secrets에서 `.env` 파일을 생성하고 서버에 업로드한 뒤,  
  `--spring.profiles.active=dev`로 애플리케이션을 실행하도록 했습니다. 

---

### 📦 컴포넌트 및 연결 타입 정의

- `ComponentType`, `ComponentSubType` enum을 정의하여 컴포넌트 분류 체계를 표준화했습니다.  
