### PR TITLE
feat: implement JWT authentication module

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -29,6 +29,14 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 	implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     runtimeOnly "com.mysql:mysql-connector-j"
     implementation "org.springframework.cloud:spring-cloud-starter-vault-config:3.1.2"
 	compileOnly 'org.projectlombok:lombok'

--- a/api-server/src/main/java/org/pado/api/core/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/api-server/src/main/java/org/pado/api/core/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,102 @@
+package org.pado.api.core.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JWT 인증 실패 시 처리하는 Entry Point
+ * 인증되지 않은 사용자가 보호된 리소스에 접근할 때 401 Unauthorized 응답을 반환
+ */
+@Component
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 인증 실패 시 호출되는 메소드
+     * 
+     * @param request HTTP 요청
+     * @param response HTTP 응답
+     * @param authException 인증 예외
+     * @throws IOException 입출력 예외
+     * @throws ServletException 서블릿 예외
+     */
+    @Override
+    public void commence(HttpServletRequest request, 
+                        HttpServletResponse response,
+                        AuthenticationException authException) throws IOException, ServletException {
+        
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+        
+        // 로그 기록
+        log.warn("인증되지 않은 요청 감지 - URI: {} {}, Message: {}", 
+                method, requestURI, authException.getMessage());
+        
+        // 응답 설정
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        
+        // 에러 응답 본문 생성
+        Map<String, Object> errorResponse = createErrorResponse(authException, requestURI);
+        
+        // JSON 응답 작성
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+    
+    /**
+     * 일관된 에러 응답 형식 생성
+     * 
+     * @param authException 인증 예외
+     * @param requestURI 요청 URI
+     * @return 에러 응답 맵
+     */
+    private Map<String, Object> createErrorResponse(AuthenticationException authException, String requestURI) {
+        Map<String, Object> errorResponse = new HashMap<>();
+        
+        errorResponse.put("status", 401);
+        errorResponse.put("error", "Unauthorized");
+        errorResponse.put("message", determineErrorMessage(authException));
+        errorResponse.put("path", requestURI);
+        errorResponse.put("timestamp", System.currentTimeMillis());
+        
+        return errorResponse;
+    }
+    
+    /**
+     * 예외 타입에 따른 적절한 에러 메시지 결정
+     * 
+     * @param authException 인증 예외
+     * @return 사용자 친화적인 에러 메시지
+     */
+    private String determineErrorMessage(AuthenticationException authException) {
+        String exceptionMessage = authException.getMessage();
+        
+        // JWT 토큰 관련 에러 메시지 분류
+        if (exceptionMessage != null) {
+            if (exceptionMessage.contains("expired")) {
+                return "토큰이 만료되었습니다. 다시 로그인해주세요.";
+            } else if (exceptionMessage.contains("malformed") || exceptionMessage.contains("invalid")) {
+                return "유효하지 않은 토큰입니다.";
+            } else if (exceptionMessage.contains("signature")) {
+                return "토큰 서명이 유효하지 않습니다.";
+            }
+        }
+        
+        // 기본 메시지
+        return "인증이 필요합니다. 로그인 후 다시 시도해주세요.";
+    }
+}

--- a/api-server/src/main/java/org/pado/api/core/security/jwt/JwtAuthenticationFilter.java
+++ b/api-server/src/main/java/org/pado/api/core/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package org.pado.api.core.security.jwt;
+
+import java.io.IOException;
+
+import org.pado.api.core.security.userdetails.CustomUserDetailsService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JWT 토큰을 검증하고 SecurityContext에 인증 정보를 설정하는 필터
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService userDetailsService;
+    private final TokenBlacklistService tokenBlacklistService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, 
+                                FilterChain filterChain) throws ServletException, IOException {
+        
+        try {
+            // 1. Request Header에서 JWT 토큰 추출
+            String jwt = getJwtFromRequest(request);
+            
+            // 2. JWT 토큰 유효성 검증
+            if (StringUtils.hasText(jwt) && jwtUtil.validateToken(jwt)) {
+                
+                // 3. Access Token인지 확인
+                if (!jwtUtil.isAccessToken(jwt)) {
+                    log.warn("Refresh Token으로 API 접근 시도");
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
+                // 4. 바로 인증 처리
+                Long userId = jwtUtil.extractUserId(jwt);
+                UserDetails userDetails = userDetailsService.loadUserById(userId);
+                
+                UsernamePasswordAuthenticationToken authentication = 
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                
+                log.debug("사용자 인증 성공: {}", userId);
+            }
+            
+        } catch (Exception e) {
+            log.warn("JWT 토큰 처리 중 오류 발생: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+    
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        
+        return null;
+    }
+    
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        
+        return path.equals("/signup") || 
+               path.equals("/signin") || 
+               path.startsWith("/swagger-ui") ||
+               path.startsWith("/v3/api-docs") ||
+               path.equals("/components") ||
+               path.startsWith("/components/search");
+    }
+}

--- a/api-server/src/main/java/org/pado/api/core/security/jwt/JwtUtil.java
+++ b/api-server/src/main/java/org/pado/api/core/security/jwt/JwtUtil.java
@@ -1,0 +1,178 @@
+package org.pado.api.core.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    // TODO : 운영 환경에서는 액세스 토큰의 만료 시간을 짧게 둘 것
+    // @Value("${jwt.access-token-expiration:3600000}")  // 기본 1시간 (1000 * 60 * 60) -> 5~15분으로 변경
+    // private long accessTokenExpiration;
+
+    // 개발환경에서는 24시간으로 해둘 것 
+    @Value("${jwt.access-token-expiration:86400000}")  // 24시간 (1000 * 60 * 60 * 24) 
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration:604800000}")  // 기본 7일 (1000 * 60 * 60 * 24 * 7)
+    private long refreshTokenExpiration;
+
+    private SecretKey getSigningKey() {
+        // secret이 너무 짧으면 에러가 발생할 수 있으므로 체크
+        if (secret.length() < 32) {
+            log.warn("JWT secret key가 너무 짧습니다. 최소 32자 이상 권장");
+        }
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Access Token 생성
+     * @param userId 사용자 ID
+     * @return JWT Access Token
+     */
+    public String generateAccessToken(String userId) {
+        return generateToken(userId, accessTokenExpiration);
+    }
+
+    /**
+     * Refresh Token 생성
+     * @param userId 사용자 ID
+     * @return JWT Refresh Token
+     */
+    public String generateRefreshToken(String userId) {
+        return generateToken(userId, refreshTokenExpiration);
+    }
+
+    /**
+     * JWT 토큰 생성 (공통 로직)
+     */
+    private String generateToken(String userId, long expirationTimeMs) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expirationTimeMs);
+
+        return Jwts.builder()
+                .setSubject(userId)
+                .claim("type", expirationTimeMs == accessTokenExpiration ? "ACCESS" : "REFRESH")
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * JWT 토큰 유효성 검증
+     * @param token JWT 토큰
+     * @return 유효하면 true, 아니면 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT token is expired: {}", e.getMessage());
+            return false;
+        } catch (UnsupportedJwtException e) {
+            log.warn("JWT token is unsupported: {}", e.getMessage());
+            return false;
+        } catch (MalformedJwtException e) {
+            log.warn("JWT token is malformed: {}", e.getMessage());
+            return false;
+        } catch (SecurityException e) {
+            log.warn("JWT signature validation failed: {}", e.getMessage());
+            return false;
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT token compact of handler are invalid: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * JWT 토큰에서 사용자 ID 추출
+     * @param token JWT 토큰
+     * @return 사용자 ID
+     */
+    public Long extractUserId(String token) {
+        String userIdStr = extractClaims(token).getSubject();
+        return Long.parseLong(userIdStr);
+    }
+
+    /**
+     * JWT 토큰에서 만료시간 추출
+     * @param token JWT 토큰
+     * @return 만료시간
+     */
+    public Date extractExpiration(String token) {
+        return extractClaims(token).getExpiration();
+    }
+
+    /**
+     * JWT 토큰이 만료되었는지 확인
+     * @param token JWT 토큰
+     * @return 만료되었으면 true
+     */
+    public boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    /**
+     * JWT 토큰에서 Claims 추출 (공통 로직)
+     * @param token JWT 토큰
+     * @return Claims
+     */
+    private Claims extractClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰이어도 Claims는 읽을 수 있음 (리프레시할 때 필요)
+            return e.getClaims();
+        }
+    }
+
+    /**
+     * Access Token인지 확인
+     * @param token JWT 토큰
+     * @return Access Token이면 true
+     */
+    public boolean isAccessToken(String token) {
+        try {
+            String type = extractClaims(token).get("type", String.class);
+            return "ACCESS".equals(type);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Refresh Token인지 확인
+     * @param token JWT 토큰
+     * @return Refresh Token이면 true
+     */
+    public boolean isRefreshToken(String token) {
+        try {
+            String type = extractClaims(token).get("type", String.class);
+            return "REFRESH".equals(type);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/api-server/src/main/java/org/pado/api/core/security/jwt/TokenBlacklistService.java
+++ b/api-server/src/main/java/org/pado/api/core/security/jwt/TokenBlacklistService.java
@@ -1,0 +1,66 @@
+package org.pado.api.core.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenBlacklistService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtUtil jwtUtil;
+    
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+    
+    /**
+     * 토큰을 블랙리스트에 추가
+     * @param token JWT 토큰
+     */
+    public void blacklistToken(String token) {
+        try {
+            // 토큰의 만료 시간 계산
+            Date expirationDate = jwtUtil.extractExpiration(token);
+            long now = System.currentTimeMillis();
+            long expiration = expirationDate.getTime() - now;
+            
+            // 이미 만료된 토큰은 블랙리스트에 추가하지 않음
+            if (expiration <= 0) {
+                log.debug("이미 만료된 토큰이므로 블랙리스트에 추가하지 않음");
+                return;
+            }
+            
+            // Redis에 토큰을 블랙리스트로 등록 (만료 시간까지만)
+            String key = BLACKLIST_PREFIX + token;
+            redisTemplate.opsForValue().set(key, "true", Duration.ofMillis(expiration));
+            
+            log.info("토큰이 블랙리스트에 추가됨: 만료까지 {}ms", expiration);
+            
+        } catch (Exception e) {
+            log.error("토큰 블랙리스트 추가 중 오류 발생: {}", e.getMessage());
+            // 블랙리스트 실패해도 로그아웃은 성공으로 처리 (보안상)
+        }
+    }
+    
+    /**
+     * 토큰이 블랙리스트에 있는지 확인
+     * @param token JWT 토큰
+     * @return 블랙리스트에 있으면 true
+     */
+    public boolean isBlacklisted(String token) {
+        try {
+            String key = BLACKLIST_PREFIX + token;
+            Boolean exists = redisTemplate.hasKey(key);
+            return Boolean.TRUE.equals(exists);
+        } catch (Exception e) {
+            log.error("블랙리스트 확인 중 오류 발생: {}", e.getMessage());
+            // Redis 오류 시 안전을 위해 블랙리스트로 간주
+            return true;
+        }
+    }
+    
+}

--- a/api-server/src/main/java/org/pado/api/core/security/jwt/TokenResponse.java
+++ b/api-server/src/main/java/org/pado/api/core/security/jwt/TokenResponse.java
@@ -1,0 +1,11 @@
+package org.pado.api.core.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/api-server/src/main/java/org/pado/api/core/security/userdetails/CustomUserDetails.java
+++ b/api-server/src/main/java/org/pado/api/core/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,130 @@
+package org.pado.api.core.security.userdetails;
+
+
+import org.pado.api.domain.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Spring Security UserDetails 인터페이스 구현체
+ * User 엔티티를 Spring Security가 이해할 수 있는 형태로 래핑
+ */
+public class CustomUserDetails implements UserDetails {
+    
+    // TODO : Role 필드 미리 만들어둘지 말지
+    private final User user;
+    
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+    
+    /**
+     * 사용자의 권한 목록을 반환
+     * @return 권한 컬렉션
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // Role enum을 Spring Security GrantedAuthority로 변환
+        return Collections.singletonList(
+            new SimpleGrantedAuthority(user.getRole().getAuthority())
+        );
+    }
+    
+    /**
+     * 사용자의 비밀번호 반환
+     * @return 암호화된 비밀번호
+     */
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+    
+    /**
+     * 사용자의 username 반환 (여기서는 email 사용)
+     * @return 이메일
+     */
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+    
+    /**
+     * 계정이 만료되지 않았는지 여부
+     * @return true (만료되지 않음)
+     */
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+    
+    /**
+     * 계정이 잠기지 않았는지 여부
+     * @return true (잠기지 않음)
+     */
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+    
+    /**
+     * 자격증명(비밀번호)이 만료되지 않았는지 여부
+     * @return true (만료되지 않음)
+     */
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+    
+    /**
+     * 계정이 활성화되어 있는지 여부
+     * @return true (활성화됨)
+     */
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+    
+    /**
+     * 원본 User 엔티티를 반환
+     * @return User 엔티티
+     */
+    public User getUser() {
+        return user;
+    }
+    
+    /**
+     * 사용자 ID 반환
+     * @return 사용자 ID
+     */
+    public Long getId() {
+        return user.getId();
+    }
+    
+    /**
+     * 사용자 이름 반환
+     * @return 사용자 이름
+     */
+    public String getName() {
+        return user.getName();
+    }
+    
+    /**
+     * 사용자 역할 반환
+     * @return Role enum
+     */
+    public Role getRole() {
+        return user.getRole();
+    }
+    
+    /**
+     * 이메일 반환
+     * @return 이메일
+     */
+    public String getEmail() {
+        return user.getEmail();
+    }
+}

--- a/api-server/src/main/java/org/pado/api/core/security/userdetails/CustomUserDetailsService.java
+++ b/api-server/src/main/java/org/pado/api/core/security/userdetails/CustomUserDetailsService.java
@@ -1,0 +1,60 @@
+package org.pado.api.core.security.userdetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.pado.api.domain.user.User;
+import org.pado.api.domain.user.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Spring Security UserDetailsService 인터페이스 구현체
+ * 사용자 인증 시 DB에서 사용자 정보를 조회하는 역할
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomUserDetailsService implements UserDetailsService {
+    
+    // TODO : exception 변경 필요
+    private final UserRepository userRepository;
+    
+    /**
+     * Spring Security 인증용 - userName 기반
+     * @param userName 사용자명 (로그인 ID)
+     * @return UserDetails 구현체
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+        log.debug("사용자 인증 시도: {}", userName);
+        
+        User user = userRepository.findByName(userName)
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: {}", userName);
+                    return new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + userName);
+                });
+        log.debug("사용자 조회 성공: {} (ID: {})", user.getName(), user.getId());
+        return new CustomUserDetails(user);
+    }
+    
+    /**
+     * JWT 인증용 - userId 기반
+     */
+    @Transactional(readOnly = true)
+    public CustomUserDetails loadUserById(Long userId) throws UsernameNotFoundException {
+        log.debug("사용자 ID로 조회: {}", userId);
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("사용자 ID를 찾을 수 없음: {}", userId);
+                    return new UsernameNotFoundException("사용자 ID를 찾을 수 없습니다: " + userId);
+                });
+        
+        log.debug("사용자 ID 조회 성공: {} (사용자명: {})", userId, user.getName());
+        return new CustomUserDetails(user);
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
#9 

## 📋 작업 내용
- [x] JWT 토큰 관리
  - JWT 생성, 검증, 파싱 유틸리티 구현
  - Access/Refresh 토큰 분리 관리
  - 토큰 만료 및 유효성 검증
  - security 의존성 추가
 
- [x] JWT 토큰 블랙리스트
  - 로그아웃된 토큰 무효화 처리
  - 토큰 블랙리스트 관리 서비스
  - redis 의존성 추가
 
- [x] 사용자 인증 서비스
  - Spring Security UserDetailsService 구현
  - 사용자 정보 조회 및 권한 관리
  - 커스텀 UserDetails 객체 구현


## 💬 리뷰 요구사항 (선택)
재 userDetails 부분의 코드에 Role 이 사용됨
이전에 상의한 적이 있는데 미리 enum Role 을 만들어 두는게 어떤지
User 필드에 Role만 추가하면 되고 다른 로직의 코드를 변경할 필요도 없음
추후 서비스 운영시 권한 관리가 필요하다고 생각됨

추가로 CustomUserDetailsService - exception 변경 필요
JwtUtil - jwt.secret을 env나 다른 보관할 수 있는 저장소가 필요

