### PR TITLE
Hotfix/#33

### DIFF
--- a/.github/workflows/dev-pull.yml
+++ b/.github/workflows/dev-pull.yml
@@ -5,6 +5,68 @@ on:
     branches: [ "dev" ]
 
 jobs:
+  env:
+    # MySQL
+    SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
+    SPRING_DATASOURCE_USERNAME: test
+    SPRING_DATASOURCE_PASSWORD: test
+    # Redis
+    SPRING_REDIS_URL: redis://test:test@localhost:6379/0
+
+    # MongoDB
+    SPRING_DATA_MONGODB_URI: mongodb://test:test@127.0.0.1:27017/testdb?authSource=admin
+
+    # Vault (dev)
+
+    VAULT_ADDR: http://127.0.0.1:8200
+    VAULT_TOKEN: root
+    
+    JWT_SECRET: test-secret
+
+  services:
+    mysql:
+      image: mysql:8.0
+      ports: ["3306:3306"]
+      env:
+        MYSQL_ROOT_PASSWORD: test
+        MYSQL_DATABASE: testdb
+        MYSQL_USER: test
+        MYSQL_PASSWORD: test
+      options: >-
+        --health-cmd="mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD || exit 1"
+        --health-interval=10s --health-timeout=5s --health-retries=10
+
+    redis:
+      image: redis:7
+      ports: ["6379:6379"]
+      # 비번이 필요하면 아래처럼:
+      # options: >-
+      #   --cmd "redis-server --requirepass redispw"
+      options: >-
+        --health-cmd="redis-cli ping || exit 1"
+        --health-interval=10s --health-timeout=3s --health-retries=10
+
+    mongo:
+      image: mongo:7
+      ports: ["27017:27017"]
+      env:
+        MONGO_INITDB_ROOT_USERNAME: test
+        MONGO_INITDB_ROOT_PASSWORD: test
+        MONGO_INITDB_DATABASE: testdb
+      options: >-
+        --health-cmd="mongosh --quiet --eval 'db.runCommand({ ping: 1 })' || exit 1"
+        --health-interval=10s --health-timeout=5s --health-retries=10
+
+    vault:
+      image: hashicorp/vault:1.15
+      ports: ["8200:8200"]
+      env:
+        VAULT_DEV_ROOT_TOKEN_ID: root
+        VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+      options: >-
+        --cap-add=IPC_LOCK
+        --health-cmd="wget -qO- http://127.0.0.1:8200/v1/sys/health || exit 1"
+        --health-interval=10s --health-timeout=5s --health-retries=20
   build-and-deploy:
     runs-on: ubuntu-latest
 
@@ -21,17 +83,27 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
 
-    - name: Start Redis
-      uses: supercharge/redis-github-action@1.4.0
-      with:
-        redis-version: '6'
+    - name: Wait for services (extra safety)
+      run: |
+        set -e
+        # MySQL
+        for i in {1..30}; do
+          nc -z 127.0.0.1 3306 && echo "MySQL up" && break || sleep 2
+        done
+        # Redis
+        for i in {1..30}; do
+          nc -z 127.0.0.1 6379 && echo "Redis up" && break || sleep 2
+        done
+        # Mongo
+        for i in {1..30}; do
+          nc -z 127.0.0.1 27017 && echo "Mongo up" && break || sleep 2
+        done
+        # Vault
+        for i in {1..30}; do
+          curl -s $VAULT_ADDR/v1/sys/health >/dev/null && echo "Vault up" && break || sleep 2
+        done
     
     - name: Run Tests and Build (in api-server)
       working-directory: api-server
-      env:
-        JWT_SECRET: ${{ secrets.JWT_SECRET }}
-        REDIS_HOST: localhost
-        REDIS_PORT: 6379
-        APP_CORS_ALLOWED_ORIGINS: "http://localhost:3000,http://localhost:5173"
       run: ./gradlew clean test build -Dspring.profiles.active=ci --info --stacktrace
     

--- a/.github/workflows/dev-pull.yml
+++ b/.github/workflows/dev-pull.yml
@@ -5,24 +5,6 @@ on:
     branches: [ "dev" ]
 
 jobs:
-  env:
-    # MySQL
-    SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
-    SPRING_DATASOURCE_USERNAME: test
-    SPRING_DATASOURCE_PASSWORD: test
-    # Redis
-    SPRING_REDIS_URL: redis://test:test@localhost:6379/0
-
-    # MongoDB
-    SPRING_DATA_MONGODB_URI: mongodb://test:test@127.0.0.1:27017/testdb?authSource=admin
-
-    # Vault (dev)
-
-    VAULT_ADDR: http://127.0.0.1:8200
-    VAULT_TOKEN: root
-    
-    JWT_SECRET: test-secret
-
   services:
     mysql:
       image: mysql:8.0
@@ -67,43 +49,59 @@ jobs:
         --cap-add=IPC_LOCK
         --health-cmd="wget -qO- http://127.0.0.1:8200/v1/sys/health || exit 1"
         --health-interval=10s --health-timeout=5s --health-retries=20
-  build-and-deploy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Source
-      uses: actions/checkout@v4
-
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-
-    - name: Wait for services (extra safety)
-      run: |
-        set -e
+    build-and-deploy:
+      env:
         # MySQL
-        for i in {1..30}; do
-          nc -z 127.0.0.1 3306 && echo "MySQL up" && break || sleep 2
-        done
+        SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
+        SPRING_DATASOURCE_USERNAME: test
+        SPRING_DATASOURCE_PASSWORD: test
         # Redis
-        for i in {1..30}; do
-          nc -z 127.0.0.1 6379 && echo "Redis up" && break || sleep 2
-        done
-        # Mongo
-        for i in {1..30}; do
-          nc -z 127.0.0.1 27017 && echo "Mongo up" && break || sleep 2
-        done
-        # Vault
-        for i in {1..30}; do
-          curl -s $VAULT_ADDR/v1/sys/health >/dev/null && echo "Vault up" && break || sleep 2
-        done
-    
-    - name: Run Tests and Build (in api-server)
-      working-directory: api-server
-      run: ./gradlew clean test build -Dspring.profiles.active=ci --info --stacktrace
-    
+        SPRING_REDIS_URL: redis://test:test@localhost:6379/0
+
+        # MongoDB
+        SPRING_DATA_MONGODB_URI: mongodb://test:test@127.0.0.1:27017/testdb?authSource=admin
+
+        # Vault (dev)
+
+        VAULT_ADDR: http://127.0.0.1:8200
+        VAULT_TOKEN: root
+        
+        JWT_SECRET: test-secret
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Wait for services (extra safety)
+        run: |
+          set -e
+          # MySQL
+          for i in {1..30}; do
+            nc -z 127.0.0.1 3306 && echo "MySQL up" && break || sleep 2
+          done
+          # Redis
+          for i in {1..30}; do
+            nc -z 127.0.0.1 6379 && echo "Redis up" && break || sleep 2
+          done
+          # Mongo
+          for i in {1..30}; do
+            nc -z 127.0.0.1 27017 && echo "Mongo up" && break || sleep 2
+          done
+          # Vault
+          for i in {1..30}; do
+            curl -s $VAULT_ADDR/v1/sys/health >/dev/null && echo "Vault up" && break || sleep 2
+          done
+      
+      - name: Run Tests and Build (in api-server)
+        working-directory: api-server
+        run: ./gradlew clean test build -Dspring.profiles.active=ci --info --stacktrace
+      

--- a/.github/workflows/dev-pull.yml
+++ b/.github/workflows/dev-pull.yml
@@ -5,103 +5,103 @@ on:
     branches: [ "dev" ]
 
 jobs:
-  services:
-    mysql:
-      image: mysql:8.0
-      ports: ["3306:3306"]
-      env:
-        MYSQL_ROOT_PASSWORD: test
-        MYSQL_DATABASE: testdb
-        MYSQL_USER: test
-        MYSQL_PASSWORD: test
-      options: >-
-        --health-cmd="mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD || exit 1"
-        --health-interval=10s --health-timeout=5s --health-retries=10
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      # MySQL
+      SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
+      SPRING_DATASOURCE_USERNAME: test
+      SPRING_DATASOURCE_PASSWORD: test
+      # Redis
+      SPRING_REDIS_URL: redis://test:test@localhost:6379/0
 
-    redis:
-      image: redis:7
-      ports: ["6379:6379"]
-      # 비번이 필요하면 아래처럼:
-      # options: >-
-      #   --cmd "redis-server --requirepass redispw"
-      options: >-
-        --health-cmd="redis-cli ping || exit 1"
-        --health-interval=10s --health-timeout=3s --health-retries=10
+      # MongoDB
+      SPRING_DATA_MONGODB_URI: mongodb://test:test@127.0.0.1:27017/testdb?authSource=admin
 
-    mongo:
-      image: mongo:7
-      ports: ["27017:27017"]
-      env:
-        MONGO_INITDB_ROOT_USERNAME: test
-        MONGO_INITDB_ROOT_PASSWORD: test
-        MONGO_INITDB_DATABASE: testdb
-      options: >-
-        --health-cmd="mongosh --quiet --eval 'db.runCommand({ ping: 1 })' || exit 1"
-        --health-interval=10s --health-timeout=5s --health-retries=10
+      # Vault (dev)
 
-    vault:
-      image: hashicorp/vault:1.15
-      ports: ["8200:8200"]
-      env:
-        VAULT_DEV_ROOT_TOKEN_ID: root
-        VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
-      options: >-
-        --cap-add=IPC_LOCK
-        --health-cmd="wget -qO- http://127.0.0.1:8200/v1/sys/health || exit 1"
-        --health-interval=10s --health-timeout=5s --health-retries=20
-    build-and-deploy:
-      env:
+      VAULT_ADDR: http://127.0.0.1:8200
+      VAULT_TOKEN: root
+      
+      JWT_SECRET: test-secret
+    services:
+      mysql:
+        image: mysql:8.0
+        ports: ["3306:3306"]
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: testdb
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD || exit 1"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+
+      redis:
+        image: redis:7
+        ports: ["6379:6379"]
+        # 비번이 필요하면 아래처럼:
+        # options: >-
+        #   --cmd "redis-server --requirepass redispw"
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=10s --health-timeout=3s --health-retries=10
+
+      mongo:
+        image: mongo:7
+        ports: ["27017:27017"]
+        env:
+          MONGO_INITDB_ROOT_USERNAME: test
+          MONGO_INITDB_ROOT_PASSWORD: test
+          MONGO_INITDB_DATABASE: testdb
+        options: >-
+          --health-cmd="mongosh --quiet --eval 'db.runCommand({ ping: 1 })' || exit 1"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+
+      vault:
+        image: hashicorp/vault:1.15
+        ports: ["8200:8200"]
+        env:
+          VAULT_DEV_ROOT_TOKEN_ID: root
+          VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+        options: >-
+          --cap-add=IPC_LOCK
+          --health-cmd="wget -qO- http://127.0.0.1:8200/v1/sys/health || exit 1"
+          --health-interval=10s --health-timeout=5s --health-retries=20
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Wait for services (extra safety)
+      run: |
+        set -e
         # MySQL
-        SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
-        SPRING_DATASOURCE_USERNAME: test
-        SPRING_DATASOURCE_PASSWORD: test
+        for i in {1..30}; do
+          nc -z 127.0.0.1 3306 && echo "MySQL up" && break || sleep 2
+        done
         # Redis
-        SPRING_REDIS_URL: redis://test:test@localhost:6379/0
-
-        # MongoDB
-        SPRING_DATA_MONGODB_URI: mongodb://test:test@127.0.0.1:27017/testdb?authSource=admin
-
-        # Vault (dev)
-
-        VAULT_ADDR: http://127.0.0.1:8200
-        VAULT_TOKEN: root
+        for i in {1..30}; do
+          nc -z 127.0.0.1 6379 && echo "Redis up" && break || sleep 2
+        done
+        # Mongo
+        for i in {1..30}; do
+          nc -z 127.0.0.1 27017 && echo "Mongo up" && break || sleep 2
+        done
+        # Vault
+        for i in {1..30}; do
+          curl -s $VAULT_ADDR/v1/sys/health >/dev/null && echo "Vault up" && break || sleep 2
+        done
+    
+    - name: Run Tests and Build (in api-server)
+      working-directory: api-server
+      run: ./gradlew clean test build -Dspring.profiles.active=ci --info --stacktrace
         
-        JWT_SECRET: test-secret
-      runs-on: ubuntu-latest
-      steps:
-      - name: Checkout Source
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Wait for services (extra safety)
-        run: |
-          set -e
-          # MySQL
-          for i in {1..30}; do
-            nc -z 127.0.0.1 3306 && echo "MySQL up" && break || sleep 2
-          done
-          # Redis
-          for i in {1..30}; do
-            nc -z 127.0.0.1 6379 && echo "Redis up" && break || sleep 2
-          done
-          # Mongo
-          for i in {1..30}; do
-            nc -z 127.0.0.1 27017 && echo "Mongo up" && break || sleep 2
-          done
-          # Vault
-          for i in {1..30}; do
-            curl -s $VAULT_ADDR/v1/sys/health >/dev/null && echo "Vault up" && break || sleep 2
-          done
-      
-      - name: Run Tests and Build (in api-server)
-        working-directory: api-server
-        run: ./gradlew clean test build -Dspring.profiles.active=ci --info --stacktrace
-      

--- a/api-server/src/main/resources/application.yaml
+++ b/api-server/src/main/resources/application.yaml
@@ -4,7 +4,10 @@ spring:
   profiles:
     active: local
 jwt:
-  secret: ${JWT_SECRET}    
+  secret: ${JWT_SECRET}
+app:
+  cors:
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}
 ---
 spring:
   config:
@@ -12,28 +15,42 @@ spring:
       on-profile: ci  
 
   datasource:
-    url: jdbc:h2:mem:ci_testdb;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: ${SPRING_DATASOURCE_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
 
   jpa:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
   
   data:
+    mongodb:
+      uri: ${SPRING_DATA_MONGODB_URI}
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      url: ${SPRING_REDIS_URL}
 
   cloud:
     vault:
-      enabled: false
-  
-  app:
-    cors:
-      allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}
+      uri: http://localhost:8200
+      token: root
+      scheme: http
+      authentication: TOKEN
+      connection-timeout: 5000
+      read-timeout: 15000
+      config:
+        lifecycle:
+          enabled: false
+
+      kv:
+        enabled: true
+        backend: secret
+        default-context: application
+        profile-separator: '-'
 ---
 spring:
   config:
@@ -62,7 +79,7 @@ spring:
     mongodb:
       uri: mongodb://${PADO_ID}:${PADO_PW}@${PADO_MONGO_DEV_URL}:27017/pado
     redis:
-      url: redis://${PADO_ID}:${PADO_PW}@${PADO_REDIS_DEV_URL}:6379/pado
+      url: redis://${PADO_ID}:${PADO_PW}@${PADO_REDIS_DEV_URL}:6379/0
   
   cloud:
     vault:
@@ -111,7 +128,7 @@ spring:
     mongodb:
       uri: mongodb://${PADO_ID}:${PADO_PW}@localhost:27017/pado
     redis:
-      url: redis://${PADO_ID}:${PADO_PW}@localhost:6379/pado
+      url: redis://${PADO_ID}:${PADO_PW}@localhost:6379/0
   
   cloud:
     vault:


### PR DESCRIPTION
## 🔗 연관된 이슈
#33 이슈

## 📋 작업 내용
This pull request updates the CI workflow and application configuration to standardize the use of real service containers (MySQL, Redis, MongoDB, Vault) instead of in-memory or mock services, and improves environment variable usage for better flexibility and security. The most important changes are grouped below:

**CI Workflow Enhancements**

* The `.github/workflows/dev-pull.yml` file now provisions MySQL, Redis, MongoDB, and Vault as Docker services for CI, with proper health checks and environment variables for each service. This replaces the previous use of a Redis GitHub Action and removes hardcoded secrets from the workflow. [[1]](diffhunk://#diff-6264664f7fc1cd89c17a0835c96ea9929a9c0538d097b0ee5a109e5be74630afR10-R70) [[2]](diffhunk://#diff-6264664f7fc1cd89c17a0835c96ea9929a9c0538d097b0ee5a109e5be74630afL24-L35)

**Application Configuration Updates**

* The `api-server/src/main/resources/application.yaml` configuration now uses environment variables for all external service connections (MySQL, Redis, MongoDB, Vault), replacing the previous H2 database setup and direct host/port references. This enables easier switching between environments and better secrets management.
* Redis connection URLs in `application.yaml` are standardized to use database index `0` instead of custom names like `pado`, ensuring consistency across environments. [[1]](diffhunk://#diff-02d671a6dc574cc998b9b059050b5c5e67f41b9c6baa64f2ba49fc61a2ad465cL65-R82) [[2]](diffhunk://#diff-02d671a6dc574cc998b9b059050b5c5e67f41b9c6baa64f2ba49fc61a2ad465cL114-R131)

**Vault Integration Improvements**

* Vault configuration in `application.yaml` is enhanced with explicit settings for URI, token, timeouts, and key-value backend options, supporting secure secret management in CI and local environments.

These changes improve reliability and security in CI, and make local/CI configuration more consistent and maintainable.

