### PR TITLE
fix: Update springdoc-openapi dependency version and modify JWT filte…

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.h2database:h2'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"

--- a/api-server/src/main/java/org/pado/api/core/security/jwt/JwtAuthenticationFilter.java
+++ b/api-server/src/main/java/org/pado/api/core/security/jwt/JwtAuthenticationFilter.java
@@ -83,12 +83,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        
-        return path.equals("/signup") || 
-               path.equals("/signin") || 
+        System.out.println("Request URI: " + path);
+        return path.startsWith("/signup") || 
+               path.startsWith("/signin") || 
                path.startsWith("/swagger-ui") ||
                path.startsWith("/v3/api-docs") ||
-               path.equals("/components") ||
+               path.startsWith("/components") ||
                path.startsWith("/components/search");
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
#36 Swagger 인증 문제

## 📋 작업 내용
> Swagger 버전 호환 문제로 `2.8.9` 버전으로 변경하여 해결 완료

This pull request updates dependencies and refines authentication filter logic to improve compatibility and security handling.

**Dependency Updates:**
* Upgraded `springdoc-openapi-starter-webmvc-ui` from version `2.1.0` to `2.8.9` in `build.gradle`, ensuring better support for OpenAPI and Swagger UI features.

**Authentication Filter Improvements:**
* Modified the JWT authentication filter in `JwtAuthenticationFilter.java` to use `startsWith` for endpoint path checks instead of `equals`, allowing authentication to be bypassed for all sub-paths of `/signup`, `/signin`, `/swagger-ui`, `/v3/api-docs`, and `/components`, which improves flexibility for those endpoints.
* Added a debug log statement to print the request URI for easier troubleshooting during development.