### PR TITLE
fix: Replace scp with rsync for deploying api-server and remove .env …

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -124,27 +124,12 @@ jobs:
             -i pado_dev_key root@localhost \
             'mkdir -p /opt/pado && exit'
 
-        scp -i pado_dev_key \
-        -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
-        -o StrictHostKeyChecking=no \
+        rsync -avz \
+        -e "ssh -i pado_dev_key \
+            -o ProxyCommand='cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org' \
+            -o StrictHostKeyChecking=no" \
         api-server/build/libs/pado-server-0.0.1-SNAPSHOT.jar \
         root@localhost:/opt/pado/api-server.jar
-
-    - name: Upload .env file to server
-      run: |
-        echo "PADO_ID=${{ secrets.PADO_ID }}" > .env
-        echo "PADO_PW=${{ secrets.PADO_PW }}" >> .env
-        echo "PADO_MYSQL_DEV_URL=${{ secrets.PADO_MYSQL_DEV_URL }}" >> .env
-        echo "PADO_VAULT_DEV_URL=${{ secrets.PADO_VAULT_DEV_URL }}" >> .env
-        echo "PADO_MONGO_DEV_URL=${{ secrets.PADO_MONGO_DEV_URL }}" >> .env
-        echo "PADO_REDIS_DEV_URL=${{ secrets.PADO_REDIS_DEV_URL }}" >> .env
-        echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
-    
-
-        scp -i pado_dev_key \
-          -o ProxyCommand="cloudflared access ssh --hostname pado-dev-ssh.taehyeok.org" \
-          -o StrictHostKeyChecking=no \
-          .env root@localhost:/opt/pado/.env
 
     - name: Kill running process (if any)
       run: |


### PR DESCRIPTION
…upload step

## 🔗 연관된 이슈
#2 

## 📋 작업 내용
This pull request updates the deployment steps in the `.github/workflows/dev.yml` workflow, focusing on improving file transfer reliability and simplifying environment variable handling.

**Deployment process improvements:**

* Replaced the use of `scp` with `rsync` for transferring the `pado-server-0.0.1-SNAPSHOT.jar` file, which provides more robust and efficient file synchronization.

**Environment variable handling:**

* Removed the step that generated and uploaded the `.env` file to the server, which previously sourced secrets from GitHub Actions and transferred them via `scp`.

