### PR TITLE
feat: add deployment and running status enums for components and proj…

### DIFF
--- a/api-server/src/main/java/org/pado/api/core/exception/ErrorCode.java
+++ b/api-server/src/main/java/org/pado/api/core/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     PROJECT_ACCESS_DENIED("P002", "프로젝트에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
     PROJECT_ALREADY_EXISTS("P003", "이미 존재하는 프로젝트입니다.", HttpStatus.CONFLICT),
     PROJECT_DELETION_NOT_ALLOWED("P004", "RUNNING 상태의 프로젝트는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PROJECT_STATUS("P005", "프로젝트 상태가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // ===== 컴포넌트 관련 에러 =====
     COMPONENT_PROJECT_MISMATCH("CP001", "해당 컴포넌트는 요청한 프로젝트에 속해 있지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/api-server/src/main/java/org/pado/api/domain/component/Component.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/Component.java
@@ -63,6 +63,8 @@ public class Component extends BaseTimeEntity {
     private ComponentType type;
     private ComponentSubType subtype;
     private String thumbnail;
+    private ComponentDeploymentStatus deploymentStatus;
+    private ComponentRunningStatus runningStatus;
     private LocalDateTime deployStartTime;
     private LocalDateTime deployEndTime;
 }

--- a/api-server/src/main/java/org/pado/api/domain/component/ComponentDeploymentStatus.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/ComponentDeploymentStatus.java
@@ -1,0 +1,13 @@
+package org.pado.api.domain.component;
+
+public enum ComponentDeploymentStatus {
+    DRAFT,
+    QUEUED,
+    DEPLOYING,
+    DEPLOYED,
+    STOP_REQUESTED,
+    TERMINATING,
+    TERMINATED,
+    FAILED,
+    CANCELLED
+}

--- a/api-server/src/main/java/org/pado/api/domain/component/ComponentRunningStatus.java
+++ b/api-server/src/main/java/org/pado/api/domain/component/ComponentRunningStatus.java
@@ -1,0 +1,8 @@
+package org.pado.api.domain.component;
+
+public enum ComponentRunningStatus {
+    DRAFT,
+    UNKNOWN,
+    RUNNING,
+    STOPPED
+}

--- a/api-server/src/main/java/org/pado/api/domain/project/Project.java
+++ b/api-server/src/main/java/org/pado/api/domain/project/Project.java
@@ -36,4 +36,6 @@ public class Project extends BaseTimeEntity{
     private String name;
     private String description;
     private String thumbnail;
+    private ProjectDeploymentStatus deploymentStatus;
+    private ProjectRunningStatus runningStatus;
 }

--- a/api-server/src/main/java/org/pado/api/domain/project/ProjectDeploymentStatus.java
+++ b/api-server/src/main/java/org/pado/api/domain/project/ProjectDeploymentStatus.java
@@ -1,0 +1,12 @@
+package org.pado.api.domain.project;
+
+public enum ProjectDeploymentStatus {
+    DRAFT,
+    QUEUED,
+    DEPLOYING,
+    DEPLOYED,
+    STOP_REQUESTED,
+    TERMINATING,
+    TERMINATED,
+    FAILED
+}

--- a/api-server/src/main/java/org/pado/api/domain/project/ProjectRunningStatus.java
+++ b/api-server/src/main/java/org/pado/api/domain/project/ProjectRunningStatus.java
@@ -1,0 +1,8 @@
+package org.pado.api.domain.project;
+
+public enum ProjectRunningStatus {
+    DRAFT,
+    UNKNOWN,
+    RUNNING,
+    STOPPED
+}

--- a/api-server/src/main/java/org/pado/api/dto/response/ComponentCreateResponse.java
+++ b/api-server/src/main/java/org/pado/api/dto/response/ComponentCreateResponse.java
@@ -1,6 +1,8 @@
 package org.pado.api.dto.response;
 
 import org.pado.api.domain.component.ComponentType;
+import org.pado.api.domain.component.ComponentDeploymentStatus;
+import org.pado.api.domain.component.ComponentRunningStatus;
 import org.pado.api.domain.component.ComponentSubType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,5 +35,17 @@ public class ComponentCreateResponse {
 
         @Schema(description = "컴포넌트 서브타입", example = "S3")
         private ComponentSubType subtype;
+
+        @Schema(description = "컴포넌트 이름", example = "My Component")
+        private String name;
+
+        @Schema(description = "컴포넌트 썸네일", example = "thumbnail.png")
+        private String thumbnail;
+
+        @Schema(description = "컴포넌트 배포 상태", example = "DRAFT")
+        private ComponentDeploymentStatus deploymentStatus;
+
+        @Schema(description = "컴포넌트 실행 상태", example = "DRAFT")
+        private ComponentRunningStatus runningStatus;
     }
 }

--- a/api-server/src/main/java/org/pado/api/dto/response/ProjectCreateResponse.java
+++ b/api-server/src/main/java/org/pado/api/dto/response/ProjectCreateResponse.java
@@ -2,7 +2,8 @@ package org.pado.api.dto.response;
 
 import java.time.LocalDateTime;
 
-import org.pado.api.domain.common.Status;
+import org.pado.api.domain.project.ProjectDeploymentStatus;
+import org.pado.api.domain.project.ProjectRunningStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -25,7 +26,10 @@ public class ProjectCreateResponse {
     private String description;
 
     @Schema(description = "프로젝트 상태", example = "DRAFT")
-    private Status status;
+    private ProjectDeploymentStatus deploymentStatus;
+
+    @Schema(description = "프로젝트 실행 상태", example = "DRAFT")
+    private ProjectRunningStatus runningStatus;
 
     @Schema(description = "프로젝트 썸네일 URL", example = "https://example.com/thumbnail.jpg")
     private String thumbnail;

--- a/api-server/src/main/java/org/pado/api/dto/response/ProjectDetailResponse.java
+++ b/api-server/src/main/java/org/pado/api/dto/response/ProjectDetailResponse.java
@@ -3,11 +3,14 @@ package org.pado.api.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.pado.api.domain.common.Status;
 import org.pado.api.domain.component.ComponentType;
+import org.pado.api.domain.project.ProjectDeploymentStatus;
+import org.pado.api.domain.project.ProjectRunningStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import org.pado.api.domain.component.ComponentDeploymentStatus;
+import org.pado.api.domain.component.ComponentRunningStatus;
 import org.pado.api.domain.component.ComponentSubType;
 
 
@@ -32,7 +35,10 @@ public class ProjectDetailResponse {
     private String thumbnail;
 
     @Schema(description = "프로젝트 상태", example = "ACTIVE")
-    private Status status;
+    private ProjectDeploymentStatus deploymentStatus;
+
+    @Schema(description = "프로젝트 실행 상태", example = "DRAFT")
+    private ProjectRunningStatus runningStatus;
 
     @Schema(description = "생성 시간", example = "2023-10-01T12:00:00Z")
     private LocalDateTime createdAt;
@@ -85,6 +91,12 @@ public class ProjectDetailResponse {
 
         @Schema(description = "컴포넌트 썸네일 URL", example = "https://example.com/component-thumbnail.jpg")
         private String thumbnail;
+
+        @Schema(description = "컴포넌트 상태", example = "ACTIVE")
+        private ComponentDeploymentStatus deploymentStatus;
+
+        @Schema(description = "컴포넌트 실행 상태", example = "DRAFT")
+        private ComponentRunningStatus runningStatus;
 
         @Schema(description = "배포 시작 시간", example = "2023-10-01T12:00:00Z")
         private LocalDateTime deployStartTime;

--- a/api-server/src/main/java/org/pado/api/dto/response/ProjectListResponse.java
+++ b/api-server/src/main/java/org/pado/api/dto/response/ProjectListResponse.java
@@ -1,6 +1,7 @@
 package org.pado.api.dto.response;
 
-import org.pado.api.domain.common.Status;
+import org.pado.api.domain.project.ProjectDeploymentStatus;
+import org.pado.api.domain.project.ProjectRunningStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -32,7 +33,10 @@ public class ProjectListResponse {
         private String description;
 
         @Schema(description = "프로젝트 상태", example = "DRAFT")
-        private Status status;
+        private ProjectDeploymentStatus deploymentStatus;
+
+        @Schema(description = "프로젝트 실행 상태", example = "DRAFT")
+        private ProjectRunningStatus runningStatus;
 
         @Schema(description = "프로젝트 썸네일 URL", example = "https://example.com/thumbnail.jpg")
         private String thumbnail;

--- a/api-server/src/main/java/org/pado/api/service/ProjectService.java
+++ b/api-server/src/main/java/org/pado/api/service/ProjectService.java
@@ -12,10 +12,11 @@ import org.pado.api.dto.response.ProjectCreateResponse;
 import org.pado.api.dto.response.ProjectDetailResponse;
 import org.pado.api.dto.response.ProjectListResponse;
 import org.pado.api.domain.project.Project;
+import org.pado.api.domain.project.ProjectDeploymentStatus;
 import org.pado.api.domain.project.ProjectRepository;
+import org.pado.api.domain.project.ProjectRunningStatus;
 import org.pado.api.domain.user.User;
 import org.springframework.stereotype.Service;
-import org.pado.api.domain.common.Status;
 import org.pado.api.domain.component.ComponentRepository;
 import org.pado.api.domain.connection.ConnectionRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,15 @@ public class ProjectService {
     private final ComponentRepository componentRepository;
     private final ConnectionRepository connectionRepository;
 
+    private static void validateComponentCreation(Project project) {
+        if (project.getDeploymentStatus() != ProjectDeploymentStatus.DRAFT &&
+            project.getDeploymentStatus() != ProjectDeploymentStatus.TERMINATED &&
+            project.getDeploymentStatus() != ProjectDeploymentStatus.DEPLOYED &&
+            project.getDeploymentStatus() != ProjectDeploymentStatus.FAILED) {
+            throw new CustomException(ErrorCode.INVALID_PROJECT_STATUS, "프로젝트가 실행 중이거나 배포 상태입니다. 설정을 변경할 수 없습니다.");
+        }
+    }
+
     @Transactional
     public ProjectCreateResponse createProject(ProjectCreateRequest request, CustomUserDetails userDetails) {
         User user = userDetails.getUser();
@@ -40,6 +50,8 @@ public class ProjectService {
                 .description(request.getDescription())
                 .user(user)
                 .thumbnail(null)
+                .deploymentStatus(ProjectDeploymentStatus.DRAFT)
+                .runningStatus(ProjectRunningStatus.DRAFT)
                 .build();
         try {
             if (projectRepository.existsByUserIdAndName(user.getId(), project.getName())) {
@@ -59,7 +71,8 @@ public class ProjectService {
                 project.getId(),
                 project.getName(),
                 project.getDescription(),
-                Status.ACTIVE,
+                project.getDeploymentStatus(),
+                project.getRunningStatus(),
                 project.getThumbnail(),
                 project.getCreatedAt(),
                 project.getUpdatedAt()
@@ -83,7 +96,8 @@ public class ProjectService {
                         project.getId(),
                         project.getName(),
                         project.getDescription(),
-                        Status.START,
+                        project.getDeploymentStatus(),
+                        project.getRunningStatus(),
                         project.getThumbnail(),
                         project.getCreatedAt(),
                         project.getUpdatedAt()
@@ -119,6 +133,8 @@ public class ProjectService {
                             component.getType(),
                             component.getSubtype(),
                             component.getThumbnail(),
+                            component.getDeploymentStatus(),
+                            component.getRunningStatus(),
                             component.getDeployStartTime(),
                             component.getDeployEndTime(),
                             component.getChildren().stream()
@@ -129,6 +145,8 @@ public class ProjectService {
                                             child.getType(),
                                             child.getSubtype(),
                                             child.getThumbnail(),
+                                            child.getDeploymentStatus(),
+                                            child.getRunningStatus(),
                                             child.getDeployStartTime(),
                                             child.getDeployEndTime(),
                                             null,
@@ -162,7 +180,8 @@ public class ProjectService {
                 project.getName(),
                 project.getDescription(),
                 project.getThumbnail(),
-                Status.ACTIVE,
+                project.getDeploymentStatus(),
+                project.getRunningStatus(),
                 project.getCreatedAt(),
                 project.getUpdatedAt(),
                 components
@@ -177,10 +196,7 @@ public class ProjectService {
         try {
             project = projectRepository.findByIdAndUserId(id, user.getId())
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND, "프로젝트를 찾을 수 없습니다."));
-            // 추후 개발 예정 부분 (프로젝트 상태를 가져오는 메소드를 통해 현재 상태를 확인 및 특정 상태일 때 삭제 가능 여부 판단)
-            // if (project.getStatus() != Status.DRAFT || project.getStatus() != Status.STOP) {
-            //     throw new CustomException(ErrorCode.PROJECT_DELETION_NOT_ALLOWED, "프로젝트 상태가 삭제를 허용하지 않습니다.");
-            // }
+            validateComponentCreation(project);
             projectRepository.delete(project);
         } catch (CustomException e) {
             log.warn("Project not found for user: {}, project ID: {}", user.getId(), id);


### PR DESCRIPTION
…ects, and update related classes

## 🔗 연관된 이슈
#68 Deploy 과정에서 필요한 Status 변수 도메인 수정

## 📋 작업 내용
This pull request introduces a more robust status management system for projects and components, refactoring the way deployment and running states are tracked and validated. It adds new enums for deployment and running statuses, updates domain models and DTOs to use these types, and enforces stricter validation on project/component operations based on their current status.

**Status Management Refactor**

* Added `ProjectDeploymentStatus`, `ProjectRunningStatus`, `ComponentDeploymentStatus`, and `ComponentRunningStatus` enums to provide more granular control and clarity over project and component states. (`api-server/src/main/java/org/pado/api/domain/project/ProjectDeploymentStatus.java` Fe9348670R1, `api-server/src/main/java/org/pado/api/domain/project/ProjectRunningStatus.java` [[1]](diffhunk://#diff-17874f4cec5a4848a2d6423dbab08bf787c97babcd814a911415f6298633c7abR1-R8) `api-server/src/main/java/org/pado/api/domain/component/ComponentDeploymentStatus.java` [[2]](diffhunk://#diff-e113d687cedf678bd84c225d76e6424ef0361cbe5dcddd3f61911de8cc5f59aaR1-R13) `api-server/src/main/java/org/pado/api/domain/component/ComponentRunningStatus.java` [[3]](diffhunk://#diff-ccba670ee95936a977e92748240698f6768d348c8f20b92e1b1725fd5df00a7cR1-R8)

* Updated `Project` and `Component` domain models to include new deployment and running status fields, replacing the previous generic status field. (`api-server/src/main/java/org/pado/api/domain/project/Project.java` [[1]](diffhunk://#diff-255fe3c0181f780c69bdf9b634c1867cfc3c2059819cee3dad07545d7b4f6ff5R39-R40) `api-server/src/main/java/org/pado/api/domain/component/Component.java` [[2]](diffhunk://#diff-7ac31241e0c12dc7f3b99079e02cd31a368ecacf23b800d9c17341540c5b4335R66-R67)

**DTO and API Response Updates**

* Refactored all relevant DTOs (`ProjectCreateResponse`, `ProjectDetailResponse`, `ProjectListResponse`, `ComponentCreateResponse`) to use the new status enums, ensuring API responses reflect the updated status model. (`api-server/src/main/java/org/pado/api/dto/response/ProjectCreateResponse.java` [[1]](diffhunk://#diff-c7884c47885dcac12561ed977ded6a1308a787d6582eae0bf9b03b181e444874L28-R32) `api-server/src/main/java/org/pado/api/dto/response/ProjectDetailResponse.java` [[2]](diffhunk://#diff-1e1b431a5bb2be76b875754761c106507b69a71031d134053d4c318374a712abL35-R41) [[3]](diffhunk://#diff-1e1b431a5bb2be76b875754761c106507b69a71031d134053d4c318374a712abR95-R100) `api-server/src/main/java/org/pado/api/dto/response/ProjectListResponse.java` [[4]](diffhunk://#diff-cf550b268f7852d1b0cb5ab9d1811cbb9bd53a8fefee865ce1208eef01914d20L35-R39) `api-server/src/main/java/org/pado/api/dto/response/ComponentCreateResponse.java` [[5]](diffhunk://#diff-821475fb833352ddce7d4bd6ead5b7d8c285dfaf86f81a12dc5c579b4f6426fbR38-R49)

**Validation and Error Handling**

* Implemented stricter validation in `ComponentService` to prevent creation, modification, or deletion of components when the parent project's status is not in an allowed state (DRAFT, TERMINATED, DEPLOYED, FAILED), and added a new error code for invalid project status. (`api-server/src/main/java/org/pado/api/service/ComponentService.java` [[1]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dL52-R68) [[2]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dR99) [[3]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dL213-R239) [[4]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dL243-R279) [[5]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dR301) [[6]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dR343) `api-server/src/main/java/org/pado/api/core/exception/ErrorCode.java` [[7]](diffhunk://#diff-3546220a24e6eadc4045d3ee633b3250196386b9dc21f644da1945ee84e3b773R41)

**Component Creation and API Consistency**

* Ensured that newly created components are initialized with `DRAFT` deployment and running statuses, and that these fields are consistently included in API responses. (`api-server/src/main/java/org/pado/api/service/ComponentService.java` [[1]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dR137-R138) [[2]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dR176-R177) [[3]](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dL197-R227)

**Code Quality Improvements**

* Improved error handling and logging in component deletion and connection management, making the codebase more robust and maintainable. (`api-server/src/main/java/org/pado/api/service/ComponentService.java` [api-server/src/main/java/org/pado/api/service/ComponentService.javaL243-R279](diffhunk://#diff-c4ce215902c1306662229f8be8fcdefd90b0a0612f0e5c1c032962beb954db8dL243-R279))

Let me know if you want to dive deeper into how these changes affect specific API endpoints or business logic!
